### PR TITLE
fix: Remove Deprecated http_application_routing Addon from AKS Deployment Configuration

### DIFF
--- a/Deployment/bicep/modules/azurekubernetesservice.bicep
+++ b/Deployment/bicep/modules/azurekubernetesservice.bicep
@@ -27,11 +27,6 @@ resource aks 'Microsoft.ContainerService/managedClusters@2021-05-01' = {
         mode: 'System'
       }
     ]
-    addonProfiles: {
-      httpApplicationRouting: {
-        enabled: true
-      }
-    }
   }
 }
 

--- a/Deployment/kubernetes/enable_approuting.psm1
+++ b/Deployment/kubernetes/enable_approuting.psm1
@@ -17,8 +17,6 @@ function Enable-AppRouting {
     # Enable application routing
     az aks approuting enable --resource-group $ResourceGroupName --name $ClusterName
 
-    # Enable HTTP application routing addon
-    az aks enable-addons --resource-group $ResourceGroupName --name $ClusterName --addons http_application_routing
 }
 
 Export-ModuleMember -Function Enable-AppRouting


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This PR removes the deprecated `http_application_routing` addon from the AKS cluster deployment in both the Bicep template and the PowerShell automation script.

### Changes:
- Removed `httpApplicationRouting` section from the AKS Bicep resource definition.
- Removed `az aks enable-addons --addons http_application_routing` command from PowerShell deployment script.

### Reason:
Microsoft has deprecated the `http_application_routing` addon, and it is no longer supported for new AKS clusters. This change aligns the deployment configuration with current best practices and prevents deployment failures.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid:

- AKS deployment completes successfully without errors or warnings related to http_application_routing.
- Cluster networking and DNS setup still works as expected.
- Ingress controller (NGINX or other) is installed and functional.
- Application routing through ingress is working correctly.
- Any dependent DNS or ingress manifests do not reference the deprecated addon.
